### PR TITLE
Correct minimum Python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     include_package_data=True,
     classifiers=[],
-    python_requires=">=3.7",
+    python_requires=">=3.11",
     install_requires=[
         # By definition, a Custom Component depends on Streamlit.
         # If your component has other Python dependencies, list


### PR DESCRIPTION
On Python 3.10 the following error happens on import:

```
ImportError: cannot import name 'StrEnum' from 'enum'
```

Looks like that class didn't exist until 3.11 (https://docs.python.org/3/library/enum.html#enum.StrEnum).